### PR TITLE
新元件：一個帶有複製按鈕的文字框（Input）

### DIFF
--- a/app/components/CopyInput.vue
+++ b/app/components/CopyInput.vue
@@ -1,0 +1,127 @@
+<!--
+  Usage:
+  <CopyInput class="address" value="106 臺北市大安區新生南路一段 3 號（國立臺北科技大學-宏裕科技研究大樓）B4 程式設計研究社"/>
+-->
+
+<script lang="ts">
+import { defineComponent, ref } from 'vue'
+
+export default defineComponent({
+  name: 'CopyInput',
+  props: {
+    value: {
+      type: String,
+      required: true,
+    },
+  },
+  setup(props) {
+    const inputRef = ref<HTMLInputElement | null>(null)
+    const message = ref('')
+    const noError = ref(true)
+    const showMessage = (msg: string, ne = true) => {
+      message.value = msg
+      noError.value = ne
+      setTimeout(() => {
+        message.value = ''
+        noError.value = true
+      }, 2000)
+    }
+    const copyToClipboard = () => {
+      // 新 API
+      if (navigator.clipboard) {
+        navigator.clipboard.writeText(props.value).then(
+          () => {
+            showMessage('複製成功')
+          },
+          () => {
+            showMessage('複製失敗', false)
+          },
+        )
+      } else if (inputRef.value) {
+        // for 老瀏覽器
+        inputRef.value.select()
+        const successful = document.execCommand('copy')
+        if (successful) {
+          showMessage('複製成功')
+        } else {
+          showMessage('複製失敗', false)
+        }
+      } else {
+        showMessage('複製失敗', false)
+      }
+    }
+    return {
+      inputRef,
+      copyToClipboard,
+      message,
+      noError,
+    }
+  },
+})
+</script>
+
+<template>
+  <div>
+    <div class="copy-input">
+      <input
+        ref="inputRef"
+        readonly
+        :value="value"
+      >
+      <button @click="copyToClipboard">
+        <svg
+          fill="#1f1f1f"
+          height="24px"
+          viewBox="0 -960 960 960"
+          width="24px"
+          xmlns="http://www.w3.org/2000/svg"
+        ><path d="M360-240q-33 0-56.5-23.5T280-320v-480q0-33 23.5-56.5T360-880h360q33 0 56.5 23.5T800-800v480q0 33-23.5 56.5T720-240H360Zm0-80h360v-480H360v480ZM200-80q-33 0-56.5-23.5T120-160v-560h80v560h440v80H200Zm160-240v-480 480Z" /></svg>
+      </button>
+    </div>
+    <p
+      v-if="message"
+      class="copied-message"
+      :class="[{ error: !noError }]"
+    >
+      {{ message }}
+    </p>
+  </div>
+</template>
+
+<style scoped>
+.copy-input {
+  display: flex;
+  align-items: center;
+  border: 0.1rem solid;
+  border-radius: 10px;
+  input {
+    flex: 10;
+    padding: 0.5rem;
+    font-size: 1rem;
+    background-color: #fff;
+    border: 0;
+    border-radius: 8px 0 0 8px;
+  }
+  button {
+    margin-left: 0;
+    width: auto;
+    border: 0;
+    border-radius: 0 8px 8px 0;
+    background-color: white;
+    img,
+    svg {
+      width: 1rem;
+      height: auto;
+      background-color: transparent;
+    }
+  }
+}
+.copied-message {
+  font-size: 0.9rem;
+  margin: 0.5rem 0 0 0;
+  transition: opacity 0.3s ease;
+  &.error {
+    color: red;
+  }
+}
+</style>

--- a/app/components/CopyInput.vue
+++ b/app/components/CopyInput.vue
@@ -1,6 +1,6 @@
 <!--
   Usage:
-  <CopyInput class="address" value="106 臺北市大安區新生南路一段 3 號（國立臺北科技大學-宏裕科技研究大樓）B4 程式設計研究社"/>
+  <CopyInput value="106 臺北市大安區新生南路一段 3 號（國立臺北科技大學-宏裕科技研究大樓）B4 程式設計研究社"/>
 -->
 
 <script lang="ts">


### PR DESCRIPTION
# CopyInput 元件
## 用法
就跟一般 `<input/>` 一樣
```html
  <CopyInput value="106 臺北市大安區新生南路一段 3 號......"/>
```
## 螢幕截圖
![image](https://github.com/user-attachments/assets/77514f3d-cdba-4c49-8412-22a1039ad306)
![image](https://github.com/user-attachments/assets/52616e00-aa56-4c3b-9d65-ef2507c41006)
## TODO
- [ ] 深色模式
- [ ] 減少複製圖示的 padding
- [ ] 訊息樣式
## 老 Co 留言：
This pull request introduces a new `CopyInput` component in the `app/components/CopyInput.vue` file. The component allows users to copy a given value to the clipboard with a button click, providing feedback on the success or failure of the copy action.

Key changes include:

* **New Component Implementation:**
  * Added a new `CopyInput` component with a template, script, and style sections. The component includes an input field and a button to copy the input value to the clipboard.
  
* **Clipboard Copy Functionality:**
  * Implemented the `copyToClipboard` method, which uses the modern `navigator.clipboard` API when available and falls back to the `document.execCommand('copy')` method for older browsers.

* **User Feedback:**
  * Added a mechanism to display success or error messages to the user after attempting to copy the value. The message is shown for 2 seconds.

* **Styling:**
  * Added scoped styles for the `CopyInput` component, including flexbox layout for the input and button, and styles for the feedback message.